### PR TITLE
Fix configuration

### DIFF
--- a/pre-commit-init/pre_commit_config.j2
+++ b/pre-commit-init/pre_commit_config.j2
@@ -89,7 +89,7 @@ repos:
 {% endif %}
 {% if 'yocto' in categories %}
   - repo: https://github.com/zarhus/oelint-adv
-    rev:  5.5.2-zarhus
+    rev: 5.5.2-zarhus
     hooks:
       - id: oelint-adv
         args: [--rulefile=.oelint-ruleset.json, --hide=info, --quiet, --fix]

--- a/pre-commit-init/pre_commit_config.j2
+++ b/pre-commit-init/pre_commit_config.j2
@@ -88,8 +88,8 @@ repos:
       - id: robocop
 {% endif %}
 {% if 'yocto' in categories %}
-  - repo: https://github.com/zarhus/oelint-adv
-    rev: 5.5.2-zarhus
+  - repo: https://github.com/priv-kweihmann/oelint-adv
+    rev: 5.7.2
     hooks:
       - id: oelint-adv
         args: [--rulefile=.oelint-ruleset.json, --hide=info, --quiet, --fix]


### PR DESCRIPTION
~~Double space in `rev:  5.5.2-zarhus` lead to pre-commit errors~~
Use upstream version, our fork had some bugs