### PR TITLE
pre-commit-config.j2: exclude `.patch` files from whitespace check

### DIFF
--- a/pre-commit-init/pre_commit_config.j2
+++ b/pre-commit-init/pre_commit_config.j2
@@ -19,7 +19,9 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        exclude: ^.*\.patch$
       - id: mixed-line-ending
+        exclude: ^.*\.patch$
 
   - repo: https://github.com/talos-systems/conform
     rev: v0.1.0-alpha.27


### PR DESCRIPTION
Fixing patches in middle might break them. Some patches might fix whitespace typos but current check would try to fix them anyway.