### PR TITLE
pre-commit-init: pre_commit_config: exclude SVG files from codespell

### DIFF
--- a/pre-commit-init/pre_commit_config.j2
+++ b/pre-commit-init/pre_commit_config.j2
@@ -34,6 +34,10 @@ repos:
     rev: v2.2.5
     hooks:
       - id: codespell
+        exclude: >
+            (?x)^(
+                .*\.svg
+            )$
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.32.0


### PR DESCRIPTION
The SVG files generate too many false positives:

```bash
codespell................................................................Failed
- hook id: codespell
- exit code: 65

dts/dts-e2e-meme.svg:20: Nd ==> And, 2nd
dts/dts-e2e-meme.svg:20: uE ==> use, due
dts/dts-e2e-meme.svg:20: bU ==> by, be, but, bug, bun, bud, buy, bum
dts/dts-e2e-meme.svg:20: nd ==> and, 2nd
dts/dts-e2e-meme.svg:20: ths ==> the, this
dts/dts-e2e-meme.svg:20: Nd ==> And, 2nd
dts/dts-e2e-meme.svg:20: Gud ==> Good
dts/dts-e2e-meme.svg:20: Bu ==> By, Be, But, Bug, Bun, Bud, Buy, Bum
dts/dts-e2e-meme.svg:20: nD ==> and, 2nd
dts/dts-e2e-meme.svg:20: OT ==> TO, OF, OR, NOT
dts/dts-e2e-meme.svg:20: fO ==> of, for, to, do, go
dts/dts-e2e-meme.svg:20: oT ==> to, of, or, not
dts/dts-e2e-meme.svg:20: OT ==> TO, OF, OR, NOT
dts/dts-e2e-meme.svg:20: fO ==> of, for, to, do, go
dts/dts-e2e-meme.svg:20: Fo ==> Of, For, To, Do, Go
dts/dts-e2e-meme.svg:20: SiE ==> size, sigh, side
dts/dts-e2e-meme.svg:20: suH ==> such
dts/dts-e2e-meme.svg:20: ND ==> AND, 2ND
dts/dts-e2e-meme.svg:20: bu ==> by, be, but, bug, bun, bud, buy, bum
dts/dts-e2e-meme.svg:20: eacG ==> each
```